### PR TITLE
Fix G formula

### DIFF
--- a/msrc/local_model.m
+++ b/msrc/local_model.m
@@ -147,7 +147,9 @@ function [sc] = calc_test(X,Su,Se,F,subg,u1,u2)
     
     [N,M] = size(X);
     
+    SuF = Su*F;    
     G = -pinv(N*Su+Se);
+    G = G*SuF;
     mu = zeros(1,M);
     for i=1:N
         vec = X(i,:);
@@ -243,7 +245,9 @@ end
 function [sc] = calc_stat(X,Su,Se,F,subg,u1,u2)    
     [N,M] = size(X);
     
+    SuF = Su*F;    
     G = -pinv(N*Su+Se);
+    G = G*SuF;
     mu = zeros(1,M);
     for i=1:N
         vec = X(i,:);


### PR DESCRIPTION
In the paper the G formula is of the form:
![image](https://user-images.githubusercontent.com/7333325/134083347-6ef4f275-59fd-423b-b401-a92c944e52b1.png)
The computaion of G in global model (https://github.com/TDteach/backdoor/blob/master/msrc/global_model.m#L46-L51) follows that, but Su*F is not mulplied in two other places. This PR adds the missing multiplications.