### PR TITLE
Fix \hat{J_t} formula

### DIFF
--- a/msrc/local_model.m
+++ b/msrc/local_model.m
@@ -280,6 +280,7 @@ function [sc] = calc_stat(X,Su,Se,F,subg,u1,u2)
         sc = sc+(up-dn);
     end
     % sc = sc/N; 
+    sc = -2 * sc;
     k = M+1;
     sc = (sc-k)/sqrt(2*k);
        

--- a/msrc/local_model.m
+++ b/msrc/local_model.m
@@ -180,8 +180,10 @@ function [sc] = calc_test(X,Su,Se,F,subg,u1,u2)
 %     sc = sc / sqrt(2*(M*M+M+1));
     
     %for KL-divergence test and Beyainsian Information Cretera
-    sc = sc/N; 
+    % sc = sc/N; 
     
+    k = M+1;
+    sc = (sc-k)/sqrt(2*k);
 %     (sc-k)/sqrt(2*k);
 %     sc = sc-log(N)*(M+M*M+1);
        
@@ -277,7 +279,9 @@ function [sc] = calc_stat(X,Su,Se,F,subg,u1,u2)
         end
         sc = sc+(up-dn);
     end
-    sc = sc/N;
+    % sc = sc/N; 
+    k = M+1;
+    sc = (sc-k)/sqrt(2*k);
        
 end
 


### PR DESCRIPTION
According to the paper, the $\hat{J_t}$ has the form of
![image](https://user-images.githubusercontent.com/7333325/134083022-b6dc5437-497d-4bd9-bd6c-38a12b0d735d.png)
While in the current codebase, it's only divided by N. This PR fixes it to conform to the paper, with the degree of freedom k=M+1, where M is the dimension of $\mu$